### PR TITLE
[fix] hostname mathching behaviour

### DIFF
--- a/js/content.js
+++ b/js/content.js
@@ -22,11 +22,11 @@ chrome.runtime.sendMessage({method: "SARgetLocalStorage"}, (response) => {
     if (host.indexOf(',') !== -1) {
       hosts = host.split(',');
       match = hosts.some((_host) => {
-        return hostname.indexOf(_host.trim()) !== -1;
+        return hostname === _host.trim();
       });
     }
     else {
-      match = hostname.indexOf(host) !== -1;
+      match = hostname === host;
     }
     return match;
   }

--- a/js/content.js
+++ b/js/content.js
@@ -39,15 +39,12 @@ chrome.runtime.sendMessage({method: "SARgetLocalStorage"}, (response) => {
     if (host.indexOf(',') !== -1) {
       hosts = host.split(',');
       match = hosts.some((_host) => {
-        return hostname.indexOf(_host.trim()) !== -1;
+        return hostname === _host.trim();
       });
       
     }
-    else {
-      match = hostname.indexOf(host) !== -1;
-    }
-    
-    return match;
+
+    return hostname === host;
   }
   
   var data = response.data;

--- a/js/content.js
+++ b/js/content.js
@@ -25,10 +25,8 @@ chrome.runtime.sendMessage({method: "SARgetLocalStorage"}, (response) => {
         return hostname === _host.trim();
       });
     }
-    else {
-      match = hostname === host;
-    }
-    return match;
+
+    return hostname === host;
   }
   
   function isExcludeHost(host) {


### PR DESCRIPTION
Hi! Thanks for amazing Chrome Extention.
I've found a probrem with subdomain matching behaviour, and fixed it.

For example, I want to avoid working with "blog.abc.com" when "abc.com" is set.

Regards.
